### PR TITLE
Fix cloud provider config

### DIFF
--- a/charts/internal/cloud-provider-config/templates/_cloud-provider-config-global.tpl
+++ b/charts/internal/cloud-provider-config/templates/_cloud-provider-config-global.tpl
@@ -2,6 +2,7 @@
 auth-url="{{ .Values.authUrl }}"
 domain-name="{{ .Values.domainName }}"
 tenant-name="{{ .Values.tenantName }}"
+project-name="{{ .Values.tenantName }}"
 username="{{ .Values.username }}"
 {{- if .Values.password }}
 password="{{ .Values.password }}"

--- a/charts/internal/cloud-provider-config/templates/_cloud-provider-config-loadbalancer.tpl
+++ b/charts/internal/cloud-provider-config/templates/_cloud-provider-config-loadbalancer.tpl
@@ -1,10 +1,10 @@
 {{- define "cloud-provider-config-loadbalancer" -}}
 [LoadBalancer]
 create-monitor=true
-monitor-delay=60s
-monitor-timeout=30s
+monitor-delay="60s"
+monitor-timeout="30s"
 monitor-max-retries=5
-lb-version=v2
+lb-version="v2"
 lb-provider="{{ .Values.lbProvider }}"
 floating-network-id="{{ .Values.floatingNetworkID }}"
 use-octavia="{{ .Values.useOctavia }}"


### PR DESCRIPTION
tenant name is being phased out in favor of project name

the other values have to be quoted in order to be parsed correctly