### PR TITLE
Revert "Cherry-pick: Add `ShootSystemComponentsHealthy` to `condition…

### DIFF
--- a/pkg/controller/healthcheck/add.go
+++ b/pkg/controller/healthcheck/add.go
@@ -79,8 +79,7 @@ func RegisterHealthChecks(mgr manager.Manager, opts healthcheck.DefaultAddArgs) 
 				HealthCheck:   general.NewSeedDeploymentHealthChecker(openstack.CSISnapshotValidationName),
 			},
 		},
-		// TODO(post v1.73): Remove this conditionTypesToRemove the future.
-		sets.New[gardencorev1beta1.ConditionType](gardencorev1beta1.ShootSystemComponentsHealthy),
+		sets.New[gardencorev1beta1.ConditionType](),
 	); err != nil {
 		return err
 	}
@@ -106,8 +105,7 @@ func RegisterHealthChecks(mgr manager.Manager, opts healthcheck.DefaultAddArgs) 
 				},
 			},
 		},
-		// TODO(post v1.73): Remove this conditionTypesToRemove the future.
-		sets.New[gardencorev1beta1.ConditionType](gardencorev1beta1.ShootSystemComponentsHealthy),
+		sets.New[gardencorev1beta1.ConditionType](),
 	)
 }
 


### PR DESCRIPTION
Revert PR because we run on gardener v1.74 and the previous commit in vendors-in v1.74. This can now be dropped.